### PR TITLE
add platform flag to cosign save

### DIFF
--- a/cmd/cosign/cli/options/save.go
+++ b/cmd/cosign/cli/options/save.go
@@ -22,6 +22,7 @@ import (
 // SaveOptions is the top level wrapper for the load command.
 type SaveOptions struct {
 	Directory string
+	Platform  string
 }
 
 var _ Interface = (*SaveOptions)(nil)
@@ -32,4 +33,7 @@ func (o *SaveOptions) AddFlags(cmd *cobra.Command) {
 		"path to dir where the signed image should be stored on disk")
 	_ = cmd.Flags().SetAnnotation("dir", cobra.BashCompSubdirsInDir, []string{})
 	_ = cmd.MarkFlagRequired("dir")
+	
+	cmd.Flags().StringVar(&o.Platform, "platform", "",
+	"only save container image and its signatures for a specific platform image")
 }

--- a/cmd/cosign/cli/save.go
+++ b/cmd/cosign/cli/save.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sigstore/cosign/v2/pkg/oci"
 	"github.com/sigstore/cosign/v2/pkg/oci/layout"
 	ociremote "github.com/sigstore/cosign/v2/pkg/oci/remote"
+	ociplatform "github.com/sigstore/cosign/v2/pkg/oci/platform"
 	"github.com/spf13/cobra"
 )
 
@@ -39,7 +40,7 @@ func Save() *cobra.Command {
 		Args:             cobra.ExactArgs(1),
 		PersistentPreRun: options.BindViper,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return SaveCmd(cmd.Context(), *o, args[0])
+			return SaveCmd(cmd.Context(), *o, args[0], o.Platform)
 		},
 	}
 
@@ -47,7 +48,7 @@ func Save() *cobra.Command {
 	return cmd
 }
 
-func SaveCmd(_ context.Context, opts options.SaveOptions, imageRef string) error {
+func SaveCmd(_ context.Context, opts options.SaveOptions, imageRef string, platform string) error {
 	ref, err := name.ParseReference(imageRef)
 	if err != nil {
 		return fmt.Errorf("parsing image name %s: %w", imageRef, err)
@@ -56,6 +57,11 @@ func SaveCmd(_ context.Context, opts options.SaveOptions, imageRef string) error
 	se, err := ociremote.SignedEntity(ref)
 	if err != nil {
 		return fmt.Errorf("signed entity: %w", err)
+	}
+
+	se, err = ociplatform.SignedEntityForPlatform(se, platform)
+	if err != nil {
+		return err
 	}
 
 	if _, ok := se.(oci.SignedImage); ok {


### PR DESCRIPTION
Adds the `--platform` flag to the save command.  I was able to re-use the logic from `cosign copy --platform` pretty seamlessly so that there wasn't much, if any, re-inventing the wheel.