### PR TITLE
retain registry in image ref

### DIFF
--- a/pkg/oci/layout/index.go
+++ b/pkg/oci/layout/index.go
@@ -25,13 +25,14 @@ import (
 )
 
 const (
-	KindAnnotation       = "kind"
-	ImageAnnotation      = "dev.cosignproject.cosign/image"
-	ImageRefAnnotation   = "org.opencontainers.image.ref.name"
-	ImageIndexAnnotation = "dev.cosignproject.cosign/imageIndex"
-	SigsAnnotation       = "dev.cosignproject.cosign/sigs"
-	AttsAnnotation       = "dev.cosignproject.cosign/atts"
-	SbomsAnnotation      = "dev.cosignproject.cosign/sboms"
+	KindAnnotation           = "kind"
+	ImageAnnotation          = "dev.cosignproject.cosign/image"
+	ImageRefAnnotation       = "org.opencontainers.image.ref.name"
+	ContainerdNameAnnotation = "io.containerd.image.name"
+	ImageIndexAnnotation     = "dev.cosignproject.cosign/imageIndex"
+	SigsAnnotation           = "dev.cosignproject.cosign/sigs"
+	AttsAnnotation           = "dev.cosignproject.cosign/atts"
+	SbomsAnnotation          = "dev.cosignproject.cosign/sboms"
 )
 
 // SignedImageIndex provides access to a local index reference, and its signatures.

--- a/pkg/oci/layout/write.go
+++ b/pkg/oci/layout/write.go
@@ -63,7 +63,7 @@ func WriteSignedImageIndex(path string, si oci.SignedImageIndex, ref name.Refere
 		return err // Return the error from getImageRef immediately.
 	}
 	if err := layoutPath.AppendIndex(si, layout.WithAnnotations(
-		map[string]string{KindAnnotation: ImageIndexAnnotation, ImageRefAnnotation: imageRef},
+		map[string]string{KindAnnotation: ImageIndexAnnotation, ImageRefAnnotation: imageRef, ContainerdNameAnnotation: ref.Name()},
 	)); err != nil {
 		return fmt.Errorf("appending signed image index: %w", err)
 	}
@@ -118,7 +118,7 @@ func appendImage(path layout.Path, img v1.Image, ref name.Reference, annotation 
 		return err // Return the error from getImageRef immediately.
 	}
 	return path.AppendImage(img, layout.WithAnnotations(
-		map[string]string{KindAnnotation: annotation, ImageRefAnnotation: imageRef},
+		map[string]string{KindAnnotation: annotation, ImageRefAnnotation: imageRef, ContainerdNameAnnotation: ref.Name()},
 	))
 }
 


### PR DESCRIPTION
~~- stop removing the registry from the index.json image ref annotations during `cosign save`.~~
~~- expect the original registry to be part of the image ref annotation during `cosign load` and replace it with target registry.~~

- create additional annotation in `index.json` that contains the full image ref including the origin registry.
- this will keep existing functionality the same and will enable newer features to use the new annotation.

If Hauler wants to reflect this in `hauler store info`, future versions can just pick up the new annotation.

`hauler store save` can also use this for the creation of the `manifest.json` required for `docker load`.

- fixes hauler-dev/hauler#321